### PR TITLE
Does not send empty objects

### DIFF
--- a/lib/Serializable.js
+++ b/lib/Serializable.js
@@ -18,7 +18,7 @@ class Serializable {
     var str = [];
     var obj = this.toObject();
     for(var p in obj) {
-      if (obj.hasOwnProperty(p)) {
+      if (obj.hasOwnProperty(p) && obj[p]) {
         str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
       }
     }


### PR DESCRIPTION
Seems to fix all our GA problems. Was fixed in the original repo but not in our fork.
